### PR TITLE
Hide and reveal auth options as appropriate

### DIFF
--- a/assets/scripts/auth/events.js
+++ b/assets/scripts/auth/events.js
@@ -8,7 +8,8 @@ const addHandlers = function () {
   $('#signup-form').on('submit', onSignUp)
   $('#signin-form').on('submit', onSignIn)
   $('#change-password-form').on('submit', onChangePassword)
-  $('#sign-out-button').on('click', onSignOut)
+  $('#sign-out').on('click', onSignOut)
+  $('.reveal-form').on('click', authUi.revealForm)
 }
 
 // SIGN UP
@@ -83,6 +84,8 @@ const onChangePassword = function (event) {
   const data = getFormFields(event.target)
   console.log('data in onChangePassword is: ', data)
   authApi.changePassword(data)
+    .then(authUi.changePasswordSuccess)
+    .catch(authUi.changePasswordError)
 }
 
 // SIGN OUT

--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -11,6 +11,12 @@ const signInSuccess = function (response) {
   store.user = response.user
   console.log('store.user is ', store.user)
   console.log('store.user.token is ', store.user.token)
+  $('#signin-form').addClass('hidden')
+  $('#signup-form').addClass('hidden')
+  $('.sign-up').addClass('hidden')
+  $('.sign-in').addClass('hidden')
+  $('#sign-out').removeClass('hidden')
+  $('.change-password').removeClass('hidden')
 }
 
 const signInError = function (error) {
@@ -20,6 +26,7 @@ const signInError = function (error) {
 const changePasswordSuccess = function (response) {
   // there is not supposed to be a response
   console.log('changePasswordSuccess response is ', response)
+  $('#change-password-form').addClass('hidden')
 }
 
 const changePasswordError = function (error) {
@@ -32,10 +39,19 @@ const signOutSuccess = function (response) {
   delete store.user
   console.log('You were successfully signed out')
   console.log('store.user after deleting it: ', store.user)
+  $('.sign-up').removeClass('hidden')
+  $('.sign-in').removeClass('hidden')
+  $('#sign-out').addClass('hidden')
+  $('.change-password').addClass('hidden')
 }
 
 const signOutError = function (error) {
   console.log('signOutError is', error)
+}
+
+const revealForm = function (event) {
+  console.log('event.target in revealForm is: ', event.target)
+  $(event.target).next().toggleClass('hidden')
 }
 
 // TODO:
@@ -49,5 +65,6 @@ module.exports = {
   changePasswordSuccess: changePasswordSuccess,
   changePasswordError: changePasswordError,
   signOutSuccess: signOutSuccess,
-  signOutError: signOutError
+  signOutError: signOutError,
+  revealForm: revealForm
 }

--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -20,6 +20,11 @@ footer {
   color: white;
 }
 
+input {
+  display: block;
+  margin: 5px auto;
+}
+
 nav {
   background-color: black;
   color: white;
@@ -28,6 +33,17 @@ nav {
 
 nav > h1 {
   margin: 0;
+}
+
+p.auth-option {
+  margin-bottom: 0;
+}
+
+.auth-option {
+  background-color: black;
+  color: white;
+  border-top: thin white solid;
+  padding: 5px 0;
 }
 
 .container-fluid {
@@ -44,6 +60,10 @@ nav > h1 {
   text-align: center;
   vertical-align: middle;
   width: 25vw;
+}
+
+.hidden {
+  display: none;
 }
 
 .navbar {

--- a/index.html
+++ b/index.html
@@ -20,23 +20,32 @@
       </nav>
 
       <section id='authentication' class="row">
-        <form id="signup-form">
-          <input name="credentials[email]" placeholder='Email' type='text' required/>
-          <input name="credentials[password]" placeholder='Password' type='password' required/>
-          <input name="credentials[password_confirmation]" placeholder='Password Confirmation' type='password' required/>
-          <button type=submit>Sign Up</button>
-        </form>
-        <form id="signin-form">
-          <input name="credentials[email]" placeholder='Email' type='text' required/>
-          <input name="credentials[password]" placeholder='Password' type='password' required/>
-          <button type=submit>Sign In</button>
-        </form>
-        <form id="change-password-form">
-          <input name="passwords[old]" placeholder='Old Password' type='password' required/>
-          <input name="passwords[new]" placeholder='New Password' type='password' required/>
-          <button type=submit>Change Password</button>
-        </form>
-        <button id="sign-out-button">Sign Out</button>
+        <div class="sign-up">
+          <p class="reveal-form auth-option">Sign Up</p>
+          <form id="signup-form" class="hidden">
+            <input name="credentials[email]" placeholder='Email' type='text' required/>
+            <input name="credentials[password]" placeholder='Password' type='password' required/>
+            <input name="credentials[password_confirmation]" placeholder='Password Confirmation' type='password' required/>
+            <button type=submit>Sign Up</button>
+          </form>
+        </div>
+        <div class="sign-in">
+          <p class="reveal-form auth-option">Sign In</p>
+          <form id="signin-form" class="hidden">
+            <input name="credentials[email]" placeholder='Email' type='text' required/>
+            <input name="credentials[password]" placeholder='Password' type='password' required/>
+            <button type=submit>Sign In</button>
+          </form>
+        </div>
+        <div class="change-password hidden">
+          <p class="reveal-form auth-option">Change Password</p>
+          <form id="change-password-form" class="hidden">
+            <input name="passwords[old]" placeholder='Old Password' type='password' required/>
+            <input name="passwords[new]" placeholder='New Password' type='password' required/>
+            <button type=submit>Change Password</button>
+          </form>
+        </div>
+        <p id="sign-out" class="auth-option hidden">Sign Out</p>
       </section>
 
       <section id="player-turns" class="row">


### PR DESCRIPTION
- Restructure HTML to display a menu item above each authentication form
- Add click handler to form menu headers that invokes `revealForm` and
toggles `hidden` class on adjacent form
- Change 'Sign Out' button to a <p> to parallel other auth menu items
- Hide 'Change Password' and 'Sign Out' sections when not signed in, via
`signInSuccess` function
- Hide 'Sign In' and 'Sign Up' sections once signed in, via
`changePasswordSuccess` and `signOutSuccess` functions
- Correcting earlier oversight, invoke `changePasswordSuccess` or
`changePasswordError` on success or failure of `onChangePassword`

TODO: Make auth options part of a hamburger menu to take up less space
TODO: Add + / - indicators to show ability to show/hide form sections