### PR TITLE
Prevent duplicate form display

### DIFF
--- a/assets/scripts/auth/ui.js
+++ b/assets/scripts/auth/ui.js
@@ -60,7 +60,15 @@ const signOutError = function (error) {
 
 const revealForm = function (event) {
   console.log('event.target in revealForm is: ', event.target)
+  console.log('$(event.target).parent() is: ', $(event.target).parent())
   $(event.target).next().toggleClass('hidden')
+  // if sign up or sign in was clicked, make sure the opposite form is hidden as
+  // this one is revealed
+  if ($(event.target).hasClass('sign-in')) {
+    $($('#signup-form').addClass('hidden'))
+  } else if ($(event.target).hasClass('sign-up')) {
+    $($('#signin-form').addClass('hidden'))
+  }
 }
 
 // displays a message to the user

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 
       <section id='authentication' class="row">
         <div class="sign-up">
-          <p class="reveal-form auth-option">Sign Up</p>
+          <p class="reveal-form auth-option sign-up">Sign Up</p>
           <form id="signup-form" class="hidden">
             <input name="credentials[email]" placeholder='Email' type='text' required/>
             <input name="credentials[password]" placeholder='Password' type='password' required/>
@@ -30,7 +30,7 @@
           </form>
         </div>
         <div class="sign-in">
-          <p class="reveal-form auth-option">Sign In</p>
+          <p class="reveal-form auth-option sign-in">Sign In</p>
           <form id="signin-form" class="hidden">
             <input name="credentials[email]" placeholder='Email' type='text' required/>
             <input name="credentials[password]" placeholder='Password' type='password' required/>


### PR DESCRIPTION
- When user clicks to reveal or hide the sign up or sign in form, hide
the opposite form to prevent having both forms open at once