### PR TITLE
Clear rematch button and alerts on signout

### DIFF
--- a/assets/scripts/auth/auth-ui.js
+++ b/assets/scripts/auth/auth-ui.js
@@ -72,8 +72,10 @@ const signOutSuccess = function (response) {
   $('.game-cell').html('')
   clearAuthForms()
   ui.updateWins()
+  ui.clearMessage()
   $('#player-x-email').html('Anonymous')
   ui.hideWinningCells()
+  $('#rematch-button').addClass('hidden')
   // change which auth options are available
   $('.sign-up').removeClass('hidden')
   $('.sign-in').removeClass('hidden')


### PR DESCRIPTION
- In `SignOutSuccess`, hide the "Demand a rematch button" and clear the
standard UI alert field (not the auth UI alert field)